### PR TITLE
Fix SSH in sparkle theme

### DIFF
--- a/zsh/themes/sparkle.zsh-theme
+++ b/zsh/themes/sparkle.zsh-theme
@@ -1,6 +1,6 @@
 function ssh_connection() {
   if [[ -n $SSH_CONNECTION ]]; then
-    return "${BOLD_MAGENTA}(ssh) "
+    echo "${BOLD_MAGENTA}(ssh) "
   fi
 }
 
@@ -12,7 +12,7 @@ BOLD_RED="%{%B%F{red}%}"
 CLEAR="%{%f%k%b%}"
 
 
-PROMPT='%{$(ssh_connection)%}'
+PROMPT='$(ssh_connection)'
 PROMPT+="✨ "
 PROMPT+="${BOLD_YELLOW}%c${CLEAR} "
 PROMPT+='$(git_prompt_info)'


### PR DESCRIPTION
Fixes ```ssh_connection:2: bad math expression: operand expected at `%{%B%F{mag...'``` in SSH session.