### PR TITLE
Retire iterm2

### DIFF
--- a/Bootstrapfile
+++ b/Bootstrapfile
@@ -7,6 +7,7 @@ gui do
   install "zoom"
   install "vlc"
   install "steam"
+  install "discord"
   install "spotify"
   install "slack"
   install "gimp"
@@ -17,12 +18,10 @@ gui do
   install "alacritty"
 
   macos do
-    install "iterm2"
     install "flux"
   end
 
   windows do
-    install "discord"
     install "flux"
   end
 end

--- a/bashrc
+++ b/bashrc
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 # zellij
-export ZELLIJ_AUTO_EXIT=true
-eval "$(zellij setup --generate-auto-start bash)"
+if [[ "$TERM_PROGRAM" != "vscode" ]] then
+  export ZELLIJ_AUTO_EXIT=true
+  eval "$(zellij setup --generate-auto-start bash)"
+fi
 
 # aliases
 alias b="bundle"

--- a/bootstrap/lib/bootstrap/package/sources.yml
+++ b/bootstrap/lib/bootstrap/package/sources.yml
@@ -169,3 +169,9 @@ zellij:
   fedora:
     dnf:
       copr: varlad/zellij
+
+discord:
+  ubuntu:
+    snap: true
+  fedora:
+    flatpak: true

--- a/test/bootstrap/fedora_test.rb
+++ b/test/bootstrap/fedora_test.rb
@@ -116,6 +116,10 @@ module Bootstrap
       test "installs alacritty" do
         assert_dnf_installed("alacritty")
       end
+
+      test "installs discord" do
+        assert_flatpak_installed("discord")
+      end
     else
       test "does not install flux" do
         assert_dnf_not_installed("fluxgui")
@@ -171,6 +175,10 @@ module Bootstrap
 
       test "does not install alacritty" do
         assert_dnf_not_installed("alacritty")
+      end
+
+      test "does not install discord" do
+        assert_flatpak_not_installed("discord")
       end
     end
 

--- a/test/bootstrap/macos_test.rb
+++ b/test/bootstrap/macos_test.rb
@@ -65,10 +65,6 @@ module Bootstrap
     end
 
     if gui?
-      test "installs iterm2" do
-        assert_brew_cask_installed("iterm2")
-      end
-
       test "installs firefox" do
         assert_brew_cask_installed("firefox")
       end
@@ -128,11 +124,11 @@ module Bootstrap
       test "installs alacritty" do
         assert_brew_cask_installed("alacritty")
       end
-    else
-      test "does not install iterm2" do
-        assert_brew_cask_not_installed("iterm2")
-      end
 
+      test "installs discord" do
+        assert_brew_cask_installed("discord")
+      end
+    else
       test "does not install flux" do
         assert_brew_cask_not_installed("flux")
       end
@@ -187,6 +183,10 @@ module Bootstrap
 
       test "does not install alacritty" do
         assert_brew_cask_not_installed("alacritty")
+      end
+
+      test "does not install discord" do
+        assert_brew_cask_not_installed("discord")
       end
     end
 

--- a/test/bootstrap/ubuntu_test.rb
+++ b/test/bootstrap/ubuntu_test.rb
@@ -116,6 +116,10 @@ module Bootstrap
       test "installs alacritty" do
         assert_snap_installed("alacritty")
       end
+
+      test "installs discord" do
+        assert_snap_installed("discord")
+      end
     else
       test "does not install flux" do
         assert_apt_not_installed("fluxgui")
@@ -171,6 +175,10 @@ module Bootstrap
 
       test "does not install alacritty" do
         assert_snap_not_installed("alacritty")
+      end
+
+      test "does not install discord" do
+        assert_snap_not_installed("discord")
       end
     end
 

--- a/test/bootstrap/windows_test.rb
+++ b/test/bootstrap/windows_test.rb
@@ -80,6 +80,10 @@ module Bootstrap
       assert_winget_installed("alacritty")
     end
 
+    test "installs discord" do
+      assert_winget_installed("discord")
+    end
+
     private
 
     def assert_winget_installed(package_name)


### PR DESCRIPTION
- Remove iterm2, we have alacritty now
- Only start zellij when we're not in a vscode terminal
- Install discord everywhere we have a gui